### PR TITLE
feat(ci): add automatic PR title and body generation

### DIFF
--- a/.github/workflows/auto-approve-merge.yml
+++ b/.github/workflows/auto-approve-merge.yml
@@ -27,7 +27,41 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Get AI Code Review
+      - name: Update PR Title and Body
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          # Fetch PR diff
+          DIFF=$(gh pr diff ${{ github.event.pull_request.number }} | head -c 3000)
+          
+          if [ -n "$DIFF" ]; then
+            # Send diff to revision API
+            RESPONSE=$(curl -s -X POST "https://xorasync-ai.hf.space/api/revisi" \
+              --data-urlencode "prompt=$DIFF" \
+              --data-urlencode "apikey=${{ secrets.NEOXR_API_KEY }}")
+            
+            # Extract generated text (assuming the API returns standard JSON like the review endpoint)
+            CONTENT=$(echo "$RESPONSE" | jq -r '.data.message')
+            
+            # If content is valid, process and update PR
+            if [ -n "$CONTENT" ] && [ "$CONTENT" != "null" ]; then
+              # The first line is treated as the Title
+              TITLE=$(echo "$CONTENT" | head -n 1)
+              
+              # The rest of the content (starting from line 3 to skip the blank line) is the Body
+              echo "$CONTENT" | tail -n +3 > pr_body.txt
+              
+              # Fallback if body becomes empty (no blank line was provided by AI)
+              if [ ! -s pr_body.txt ]; then
+                 echo "$CONTENT" | tail -n +2 > pr_body.txt
+              fi
+
+              # Apply changes to the Pull Request
+              gh pr edit ${{ github.event.pull_request.number }} --title "$TITLE" --body-file pr_body.txt
+            fi
+          fi
+
+      - name: AI Code Review
         id: ai-review
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Description
This pull request enhances the existing automation workflow to automatically generate and update Pull Request titles and descriptions based on code changes using an external AI API.

### Changes Made
- Added `Update PR Title and Body` step to the `.github/workflows/auto-approve-merge.yml` workflow.
- Implemented a script to fetch the PR diff (capped at 3000 characters) and send it to the `xorasync-ai` API.
- Included logic to parse the API response and split it into a title and body.
- Used the GitHub CLI (`gh pr edit`) to update the PR metadata dynamically.
- Renamed the previous code review step to `AI Code Review` for consistency.
