### PR TITLE
chore(deps): bump @neoxr/wb from 6.0.0-rc.45 to 6.0.0-rc.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
    "homepage": "https://github.com/neoxr/neoxr-bot#readme",
    "dependencies": {
       "@adiwajshing/keyed-db": "^0.2.4",
-      "@neoxr/wb": "^6.0.0-rc.45",
+      "@neoxr/wb": "^6.0.0-rc.46",
       "audio-decode": "^2.1.3",
       "baileys": "npm:@itsliaaa/baileys",
       "cfonts": "3.1.1",


### PR DESCRIPTION
### Description
This pull request updates the version of the `@neoxr/wb` dependency.

### Changes Made
- Updated `@neoxr/wb` dependency version from `^6.0.0-rc.45` to `^6.0.0-rc.46` in `package.json`.
