### PR TITLE
feat: add preview-link type and landscape ratio to message modify

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -198,6 +198,9 @@ export default async (client, ctx) => {
                client.sendMessageModify(m.chat, `⚠️ Using bot in private chat only for premium user, want to upgrade to premium plan ? send *${prefixes[0]}premium* to see benefit and prices.`, m, {
                   largeThumb: true,
                   thumbnail: 'https://telegra.ph/file/0b32e0a0bb3b81fef9838.jpg',
+                  type: 'preview-link',
+                  /* choose: landscape (default), potrait, square */
+                  ratio: 'landscape',
                   url: setting.link
                }).then(() => chats.lastchat = new Date() * 1)
                continue

--- a/lib/listeners-extra.js
+++ b/lib/listeners-extra.js
@@ -118,6 +118,9 @@ export default (system, client) => {
             if (groupSet && groupSet.welcome) sock.sendMessageModify(ctx.jid, txt, null, {
                largeThumb: true,
                thumbnail: pic,
+               type: 'preview-link',
+               /* choose: landscape (default), potrait, square */
+               ratio: 'landscape',
                url: global.db.setting.link
             })
          } catch (e) {
@@ -152,6 +155,9 @@ export default (system, client) => {
             if (groupSet && groupSet.left) sock.sendMessageModify(ctx.jid, txt, null, {
                largeThumb: true,
                thumbnail: pic,
+               type: 'preview-link',
+               /* choose: landscape (default), potrait, square */
+               ratio: 'landscape',
                url: global.db.setting.link
             })
          } catch (e) {

--- a/lib/models.js
+++ b/lib/models.js
@@ -60,7 +60,7 @@ export const models = {
       onlyprefix: '+',
       owners: ['994408364923'],
       lastReset: new Date * 1,
-      msg: 'Hi +tag 🪸\nI am an automated system (WhatsApp Bot) that can help to do something, search and get data / information only through WhatsApp.\n\n◦ *Module* : +module\n◦ *Database* : +db\n◦ *Library* : Baileys +version\n◦ *Rest API* : https://api.neoxr.my.id\n◦ *Source* : https://github.com/neoxr/neoxr-bot\n\nIf you find an error or want to upgrade premium plan contact the owner.',
+      msg: 'Hi +tag 🪸\nI am an automated system (WhatsApp Bot) that can help to do something, search and get data / information only through WhatsApp.\n\n◦ *Module* : +module\n◦ *Database* : +db\n◦ *Library* : Baileys +version\n\nIf you find an error or want to upgrade premium plan contact the owner.',
       style: 4,
       cover: 'https://imgkub.com/images/2025/09/24/image0fe254c6cbb0910a.jpg',
       link: 'https://chat.whatsapp.com/D4OaImtQwH48CtlR0yt4Ff'

--- a/plugins/_events/downloader/autodl_mediafire.js
+++ b/plugins/_events/downloader/autodl_mediafire.js
@@ -40,6 +40,9 @@ export const run = {
                   if (chSize.oversize) return client.reply(m.chat, isOver, m)
                   client.sendMessageModify(m.chat, text, m, {
                      largeThumb: true,
+                     type: 'preview-link',
+                     /* choose: landscape (default), potrait, square */
+                     ratio: 'landscape',
                      thumbnail: 'https://telegra.ph/file/fcf56d646aa059af84126.jpg'
                   }).then(async () => {
                      client.sendFile(m.chat, json.data.url, unescape(decode(json.data.title)), '', m)

--- a/plugins/_events/downloader/autodl_yt.js
+++ b/plugins/_events/downloader/autodl_yt.js
@@ -48,6 +48,9 @@ export const run = {
                   let isSize = (json.data.size).replace(/MB/g, '').trim()
                   if (isSize > 99) return client.sendMessageModify(m.chat, caption, m, {
                      largeThumb: true,
+                     type: 'preview-link',
+                     /* choose: landscape (default), potrait, square */
+                     ratio: 'landscape',
                      thumbnail: await Utils.fetchAsBuffer(json.thumbnail)
                   }).then(async () => {
                      await client.sendFile(m.chat, json.data.buffer, json.data.filename, caption, m, {

--- a/plugins/download/mediafire.js
+++ b/plugins/download/mediafire.js
@@ -34,6 +34,9 @@ export const run = {
          if (chSize.oversize) return client.reply(m.chat, isOver, m)
          client.sendMessageModify(m.chat, text, m, {
             largeThumb: true,
+            type: 'preview-link',
+            /* choose: landscape (default), potrait, square */
+            ratio: 'landscape',
             thumbnail: 'https://telegra.ph/file/fcf56d646aa059af84126.jpg'
          }).then(async () => {
             client.sendFile(m.chat, json.data.url, unescape(decode(json.data.title)), '', m)

--- a/plugins/download/play.js
+++ b/plugins/download/play.js
@@ -29,6 +29,9 @@ export const run = {
          if (chSize.oversize) return client.reply(m.chat, isOver, m)
          client.sendMessageModify(m.chat, caption, m, {
             largeThumb: true,
+            type: 'preview-link',
+            /* choose: landscape (default), potrait, square */
+            ratio: 'landscape',
             thumbnail: json.thumbnail
          }).then(async () => {
             client.sendFile(m.chat, json.data.url, json.data.filename, '', m, {

--- a/plugins/download/youtube.js
+++ b/plugins/download/youtube.js
@@ -34,6 +34,9 @@ export const run = {
             if (chSize.oversize) return client.reply(m.chat, isOver, m)
             client.sendMessageModify(m.chat, caption, m, {
                largeThumb: true,
+               type: 'preview-link',
+               /* choose: landscape (default), potrait, square */
+               ratio: 'landscape',
                thumbnail: await Utils.fetchAsBuffer(json.thumbnail)
             }).then(async () => {
                client.sendFile(m.chat, json.data.url, json.data.filename, '', m, {
@@ -72,6 +75,9 @@ export const run = {
             let isSize = (json.data.size).replace(/MB/g, '').trim()
             if (isSize > 99) return client.sendMessageModify(m.chat, caption, m, {
                largeThumb: true,
+               type: 'preview-link',
+               /* choose: landscape (default), potrait, square */
+               ratio: 'landscape',
                thumbnail: await Utils.fetchAsBuffer(json.thumbnail)
             }).then(async () => {
                await client.sendFile(m.chat, json.data.url, json.data.filename, caption, m, {

--- a/plugins/download/yt-playlist.js
+++ b/plugins/download/yt-playlist.js
@@ -38,6 +38,9 @@ export const run = {
                if (chSize.oversize) return client.reply(m.chat, isOver, m)
                client.sendMessageModify(m.chat, caption, m, {
                   largeThumb: true,
+                  type: 'preview-link',
+                  /* choose: landscape (default), potrait, square */
+                  ratio: 'landscape',
                   thumbnail: await Utils.fetchAsBuffer(json.thumbnail)
                }).then(async () => {
                   client.sendFile(m.chat, json.data.url, json.data.filename, '', m, {
@@ -73,6 +76,9 @@ export const run = {
                let isSize = (json.data.size).replace(/MB/g, '').trim()
                if (isSize > 99) return client.sendMessageModify(m.chat, caption, m, {
                   largeThumb: true,
+                  type: 'preview-link',
+                  /* choose: landscape (default), potrait, square */
+                  ratio: 'landscape',
                   thumbnail: await Utils.fetchAsBuffer(json.thumbnail)
                }).then(async () => {
                   await client.sendFile(m.chat, json.data.url, json.data.filename, caption, m, {

--- a/plugins/group/groupinfo.js
+++ b/plugins/group/groupinfo.js
@@ -40,6 +40,9 @@ export const run = {
          caption += global.footer
          client.sendMessageModify(m.chat, caption, m, {
             largeThumb: true,
+            type: 'preview-link',
+            /* choose: landscape (default), potrait, square */
+            ratio: 'square',
             thumbnail: picture
          })
       } catch (e) {

--- a/plugins/menu.js
+++ b/plugins/menu.js
@@ -68,6 +68,9 @@ export const run = {
             client.sendMessageModify(m.chat, Utils.Styles(print) + '\n\n' + global.footer, m, {
                ads: false,
                largeThumb: true,
+               type: 'preview-link',
+               /* choose: landscape (default), potrait, square */
+               ratio: 'landscape',
                thumbnail: Utils.isUrl(setting.cover) ? setting.cover : Buffer.from(setting.cover, 'base64'),
                url: setting.link
             })
@@ -120,8 +123,10 @@ export const run = {
                }).join('\n')
             }
             client.sendMessageModify(m.chat, Utils.Styles(print) + '\n\n' + global.footer, m, {
-               ads: false,
                largeThumb: true,
+               type: 'preview-link',
+               /* choose: landscape (default), potrait, square */
+               ratio: 'landscape',
                thumbnail: Utils.isUrl(setting.cover) ? setting.cover : Buffer.from(setting.cover, 'base64'),
                url: setting.link
             })
@@ -174,8 +179,10 @@ export const run = {
                }).join('\n')
             }
             client.sendMessageModify(m.chat, print + '\n\n' + global.footer, m, {
-               ads: false,
                largeThumb: true,
+               type: 'preview-link',
+               /* choose: landscape (default), potrait, square */
+               ratio: 'landscape',
                thumbnail: Utils.isUrl(setting.cover) ? setting.cover : Buffer.from(setting.cover, 'base64'),
                url: setting.link
             })
@@ -237,8 +244,10 @@ export const run = {
                   }
                }).join('\n')
                client.sendMessageModify(m.chat, print + '\n\n' + global.footer, m, {
-                  ads: false,
                   largeThumb: true,
+                  type: 'preview-link',
+                  /* choose: landscape (default), potrait, square */
+                  ratio: 'landscape',
                   thumbnail: Utils.isUrl(setting.cover) ? setting.cover : Buffer.from(setting.cover, 'base64'),
                   url: setting.link
                })

--- a/plugins/miscs/botstat.js
+++ b/plugins/miscs/botstat.js
@@ -32,6 +32,9 @@ export const run = {
 
          await client.sendMessageModify(m.chat, buildStatisticMessage(Utils, stats, system), m, {
             largeThumb: true,
+            type: 'preview-link',
+            /* choose: landscape (default), potrait, square */
+            ratio: 'landscape',
             thumbnail: Utils.isUrl(setting.cover) ? setting.cover : Buffer.from(setting.cover, 'base64')
          })
       } catch (error) {

--- a/plugins/miscs/hitstat.js
+++ b/plugins/miscs/hitstat.js
@@ -27,8 +27,10 @@ export const run = {
       teks += sorted.slice(0, show).map(([cmd, prop], i) => '   ┌ ' + Utils.texted('bold', 'Command') + ' :  ' + Utils.texted('monospace', isPrefix + cmd) + '\n   │ ' + Utils.texted('bold', 'Hit') + ' : ' + Utils.formatNumber(command == 'hitstat' ? prop.hitstat : prop.today) + 'x\n   └ ' + Utils.texted('bold', 'Last Hit') + ' : ' + format(prop.lasthit, 'dd/MM/yy HH:mm:ss')).join`\n\n`
       teks += `\n\n${global.footer}`
       client.sendMessageModify(m.chat, teks, m, {
-         ads: false,
          largeThumb: true,
+         type: 'preview-link',
+         /* choose: landscape (default), potrait, square */
+         ratio: 'landscape',
          thumbnail: Utils.isUrl(setting.cover) ? setting.cover : Buffer.from(setting.cover, 'base64'),
       })
    },

--- a/plugins/miscs/server.js
+++ b/plugins/miscs/server.js
@@ -20,8 +20,10 @@ export const run = {
          caption += `└  ◦  Processor : ${os.cpus()[0].model}\n\n`
          caption += global.footer
          client.sendMessageModify(m.chat, caption, m, {
-            ads: false,
             largeThumb: true,
+            type: 'preview-link',
+            /* choose: landscape (default), potrait, square */
+            ratio: 'landscape',
             thumbnail: Utils.isUrl(setting.cover) ? setting.cover : Buffer.from(setting.cover, 'base64')
          })
       } catch (e) {

--- a/plugins/owner/broadcast.js
+++ b/plugins/owner/broadcast.js
@@ -136,6 +136,9 @@ export const run = {
                   title: global.botname,
                   thumbnail: await Utils.fetchAsBuffer('https://telegra.ph/file/aa76cce9a61dc6f91f55a.jpg'),
                   largeThumb: true,
+                  type: 'preview-link',
+                  /* choose: landscape (default), potrait, square */
+                  ratio: 'landscape',
                   url: setting.link,
                   mentions: command == 'bcgc' ? member : []
                })

--- a/plugins/owner/gc.js
+++ b/plugins/owner/gc.js
@@ -143,6 +143,9 @@ export const run = {
                   group
                }) + '\n\n' + global.footer, m, {
                   largeThumb: true,
+                  type: 'preview-link',
+                  /* choose: landscape (default), potrait, square */
+                  ratio: 'landscape',
                   thumbnail: picture
                })
             }

--- a/plugins/userinfo/me.js
+++ b/plugins/userinfo/me.js
@@ -29,6 +29,9 @@ export const run = {
       caption += global.footer
       client.sendMessageModify(m.chat, caption, m, {
          largeThumb: true,
+         type: 'preview-link',
+         /* choose: landscape (default), potrait, square */
+         ratio: 'square',
          thumbnail: avatar
       })
    },

--- a/plugins/userinfo/profile.js
+++ b/plugins/userinfo/profile.js
@@ -42,6 +42,9 @@ export const run = {
          caption += global.footer
          client.sendMessageModify(m.chat, caption, m, {
             largeThumb: true,
+            type: 'preview-link',
+            /* choose: landscape (default), potrait, square */
+            ratio: 'square',
             thumbnail: avatar
          })
       }

--- a/plugins/utilities/gempa.js
+++ b/plugins/utilities/gempa.js
@@ -19,6 +19,9 @@ export const run = {
          caption += global.footer
          client.sendMessageModify(m.chat, caption, m, {
             largeThumb: true,
+            type: 'preview-link',
+            /* choose: landscape (default), potrait, square */
+            ratio: 'square',
             thumbnail: await Utils.fetchAsBuffer(json.data.map)
          })
       } catch (e) {

--- a/plugins/utilities/google.js
+++ b/plugins/utilities/google.js
@@ -23,11 +23,7 @@ export const run = {
                teks += '	◦  *Snippet* : ' + v.description + '\n'
                teks += '	◦  *Link* : ' + v.url + '\n\n'
             })
-            client.sendMessageModify(m.chat, teks + global.footer, m, {
-               ads: false,
-               largeThumb: true,
-               thumbnail: await Utils.fetchAsBuffer('https://telegra.ph/file/d7b761ea856b5ba7b0713.jpg')
-            })
+            client.reply(m.chat, teks + global.footer, m)
          } else if (command == 'goimg') {
             const json = await Api.neoxr('/goimg', {
                q: text


### PR DESCRIPTION
### Description
This PR updates the messaging configuration to use preview links with a landscape ratio and streamlines the default bot message template.

### Changes Made
- Added `type: 'preview-link'` and `ratio: 'landscape'` to `sendMessageModify` calls in `handler.js`.
- Added `type: 'preview-link'` and `ratio: 'landscape'` to welcome and leave message triggers in `lib/listeners-extra.js`.
- Updated the default message template in `lib/models.js` to remove redundant Rest API and Source links.
