### PR TITLE
feat: add button8 example and update broadcast logic

### DIFF
--- a/plugins/example/button.js
+++ b/plugins/example/button.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
 export const run = {
-   usage: ['button1', 'button2', 'button3', 'button4', 'button5', 'button6', 'button7'],
+   usage: ['button1', 'button2', 'button3', 'button4', 'button5', 'button6', 'button7', 'button8'],
    category: 'example',
    async: async (m, {
       client,
@@ -213,6 +213,16 @@ export const run = {
                })
                break
             }
+
+            case 'button8':
+               client.sendIAMessage(m.chat, [{
+                  name: 'inapp_signup',
+                  buttonParamsJson: JSON.stringify({})
+               }], m, {
+                  header: global.header,
+                  content: 'Hi! @0'
+               })
+               break
          }
       } catch (e) {
          client.reply(m.chat, Utils.jsonFormat(e), m)

--- a/plugins/owner/broadcast.js
+++ b/plugins/owner/broadcast.js
@@ -131,17 +131,13 @@ export const run = {
             for (let jid of id) {
                const room = group ? jid.id : jid
                const member = group ? client.lidParser(jid?.participants)?.map(v => v.id) : []
-               await client.sendMessageModify(room, text, null, {
-                  netral: true,
-                  title: global.botname,
-                  thumbnail: await Utils.fetchAsBuffer('https://telegra.ph/file/aa76cce9a61dc6f91f55a.jpg'),
-                  largeThumb: true,
-                  type: 'preview-link',
-                  /* choose: landscape (default), potrait, square */
-                  ratio: 'landscape',
-                  url: setting.link,
-                  mentions: command == 'bcgc' ? member : []
-               })
+               client.sendIAMessage(room, [{
+                  name: 'inapp_signup',
+                  buttonParamsJson: JSON.stringify({})
+               }], null, {
+                  header: 'Broadcast Message 📢',
+                  content: text
+               }, { mentionedJid: command === 'bcgc' ? member : [] })
                await Utils.delay(1500)
             }
             return client.reply(m.chat, Utils.texted('bold', `🚩 Successfully send broadcast message to ${id.length} ${command == 'bc' ? 'chats' : command === 'bcprem' ? 'premium users' : 'groups'}`), m)


### PR DESCRIPTION
### Description
This pull request updates the plugin structure, introduces a new button example, and refactors the broadcast logic to use interactive messages.

### Changes Made
- Moved `plugins/button.js` to `plugins/example/button.js`.
- Added `button8` to the command usage list in `plugins/example/button.js`.
- Implemented `button8` case logic using `client.sendIAMessage` with an `inapp_signup` button parameter.
- Updated `plugins/owner/broadcast.js` to use `client.sendIAMessage` instead of `client.sendMessageModify`, simplifying the broadcast message format and adding a header.
