### PR TITLE
feat(downloader): support album messages for pinterest

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,6 +1,6 @@
 import { Client, Config, Utils } from '@neoxr/wb'
 import baileys from './lib/engine.js'
-import './lib/proto.js'
+// import './lib/proto.js'
 import './error.js'
 import './lib/config.js'
 import './lib/functions.js'

--- a/plugins/_events/downloader/autodl_pin.js
+++ b/plugins/_events/downloader/autodl_pin.js
@@ -26,11 +26,9 @@ export const run = {
                      url: link
                   })
                   if (!json.status) return client.reply(m.chat, Utils.jsonFormat(json), m)
-                  if (/jpg/.test(json.data.type)) return client.sendFile(m.chat, json.data.url, '', `🍟 *Fetching* : ${((new Date - old) * 1)} ms`, m)
-                  if (/mp4|gif/.test(json.data.type)) {
-                     const buffer = await Converter.toVideo(json.data.url)
-                     client.sendFile(m.chat, buffer, '', `🍟 *Fetching* : ${((new Date - old) * 1)} ms`, m)
-                  }
+                  if (json.data?.length === 1) return client.sendFile(m.chat, json.data[0].url, '', `🍟 *Fetching* : ${((new Date - old) * 1)} ms`, m)
+                  const files = json.data.map(v => ({ url: v.url }))
+                  client.sendAlbumMessage(m.chat, files, m)
                })
             }
          }

--- a/plugins/download/pin.js
+++ b/plugins/download/pin.js
@@ -1,5 +1,3 @@
-import { Converter } from '@neoxr/wb'
-
 export const run = {
    usage: ['pin'],
    hidden: ['pinterest'],
@@ -7,26 +5,24 @@ export const run = {
    category: 'downloader',
    async: async (m, {
       client,
+      args,
       text,
       isPrefix,
       command,
       Utils
    }) => {
       try {
-         if (!text) return client.reply(m.chat, Utils.example(isPrefix, command, 'https://pin.it/5fXaAWE'), m)
+         if (!text) return client.reply(m.chat, Utils.example(isPrefix, command, 'https://pin.it/6oMTJmFiq'), m)
          client.sendReact(m.chat, '🕒', m.key)
          let old = new Date()
          if (Utils.isUrl(text.trim())) {
             if (!text.match(/pin(?:terest)?(?:\.it|\.com)/)) return m.reply(global.status.invalid)
-            const json = await Api.neoxr('/pin', {
-               url: text.trim()
-            })
+            const [url] = args
+            const json = await Api.neoxr('/pin', { url })
             if (!json.status) return client.reply(m.chat, Utils.jsonFormat(json), m)
-            if (/jpg/.test(json.data.type)) return client.sendFile(m.chat, json.data.url, '', `🍟 *Fetching* : ${((new Date - old) * 1)} ms`, m)
-            if (/mp4|gif/.test(json.data.type)) {
-               const buffer = await Converter.toVideo(json.data.url)
-               client.sendFile(m.chat, buffer, '', `🍟 *Fetching* : ${((new Date - old) * 1)} ms`, m)
-            }
+            if (json.data?.length === 1) return client.sendFile(m.chat, json.data[0].url, '', `🍟 *Fetching* : ${((new Date - old) * 1)} ms`, m)
+            const files = json.data.map(v => ({ url: v.url }))
+            client.sendAlbumMessage(m.chat, files, m)
          } else {
             const json = await Api.neoxr('/pinterest', {
                q: text.trim()


### PR DESCRIPTION
### Description
Updated the Pinterest downloader to handle multi-item responses using album messages and simplified the download logic across plugins.

### Changes Made
- *client.js*: Commented out the `import './lib/proto.js'` line.
- *plugins/_events/downloader/autodl_pin.js*:
  - Updated to check for array length in the response data.
  - Replaced manual file-type checking and video conversion with a more direct approach.
  - Implemented `client.sendAlbumMessage` to handle multiple files in a single download trigger.
- *plugins/download/pin.js*:
  - Removed unused `Converter` import.
  - Updated usage example URL.
  - Optimized URL extraction using `args`.
  - Refactored logic to use `client.sendAlbumMessage` for multiple assets and `client.sendFile` for single assets.
