### PR TITLE
chore: disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Have you checked the Baileys issue?
     about: Check the open/closed issues to make sure the bug comes from Baileys or from the script.


### PR DESCRIPTION
### Description
This pull request updates the repository configuration to disable the creation of blank issues. Users will now be required to use the defined issue templates.

### Changes Made
- Updated `.github/ISSUE_TEMPLATE/config.yml` to set `blank_issues_enabled` to `false`.
