### PR TITLE
fix: correct property reference and update command metadata

### DIFF
--- a/plugins/_events/read_viewonce.js
+++ b/plugins/_events/read_viewonce.js
@@ -11,7 +11,7 @@ export const run = {
       groupSet
    }) => {
       try {
-         if (!m.fromMe && m?.msg?.viewOnce && (m.isGroup ? groupSet.viewOnce : true)) {
+         if (!m.fromMe && m?.msg?.viewOnce && (m.isGroup ? groupSet.viewonce : true)) {
             const type = Object.keys(m.message)?.[0]
             const message = m.message?.[type]
 

--- a/plugins/owner/update.js
+++ b/plugins/owner/update.js
@@ -6,7 +6,7 @@ const execPromise = util.promisify(exec)
 export const run = {
    usage: ['update'],
    hidden: ['up'],
-   category: 'operator',
+   category: 'owner',
    async: async (m, {
       client,
       Utils
@@ -38,5 +38,5 @@ export const run = {
          }
       }
    },
-   operator: true
+   owner: true
 }


### PR DESCRIPTION
### Description
This pull request fixes an incorrect property reference in the view-once event handler and updates the metadata/permission configuration for the update command.

### Changes Made
- *plugins/_events/read_viewonce.js*: Corrected `groupSet.viewOnce` to `groupSet.viewonce` to ensure proper condition checking.
- *plugins/owner/update.js*: Updated `category` from `operator` to `owner`.
- *plugins/owner/update.js*: Replaced the `operator: true` flag with `owner: true` to align with the new permission structure.
