### PR TITLE
feat: add webp support to sticker_custom plugin

### DIFF
--- a/plugins/example/sticker_custom.js
+++ b/plugins/example/sticker_custom.js
@@ -10,7 +10,7 @@ export const run = {
       try {
          const q = m.quoted ? m.quoted : m
          const mime = (q.msg || q).mimetype || ''
-         if (/image\/(jpe?g|png)/.test(mime)) {
+         if (/image\/(jpe?g|png|webp)/.test(mime)) {
             const buffer = await q.download()
             if (!buffer) return client.reply(m.chat, global.status.wrong, m)
             await client.sendReact(m.chat, '🕒', m.key)


### PR DESCRIPTION
### Description
This change extends the supported image formats for the custom sticker plugin to include the `webp` mime type.

### Changes Made
- Modified the regular expression in `plugins/example/sticker_custom.js` to allow `image/webp` in addition to `jpeg` and `png`.
