### PR TITLE
fix(downloader): switch from buffer to URL in YouTube auto-downloader

### DIFF
--- a/plugins/_events/downloader/autodl_yt.js
+++ b/plugins/_events/downloader/autodl_yt.js
@@ -55,11 +55,11 @@ export const run = {
                      thumbnail: await Utils.fetchAsBuffer(json.thumbnail),
                      icon: setting.icon ? Utils.isUrl(setting.icon) ? setting.icon : Buffer.from(setting.icon, 'base64') : null
                   }).then(async () => {
-                     await client.sendFile(m.chat, json.data.buffer, json.data.filename, caption, m, {
+                     await client.sendFile(m.chat, json.data.url, json.data.filename, caption, m, {
                         document: true
                      })
                   })
-                  client.sendFile(m.chat, json.data.buffer, json.data.filename, caption, m)
+                  client.sendFile(m.chat, json.data.url, json.data.filename, caption, m)
                })
             }
          }


### PR DESCRIPTION
### Description
This change updates the automatic YouTube downloader event to utilize URLs instead of buffers when sending files. This helps in reducing memory consumption by avoiding the loading of entire video buffers into RAM.

### Changes Made
- Updated `client.sendFile` calls in `plugins/_events/downloader/autodl_yt.js` to pass `json.data.url` instead of `json.data.buffer`.
- Applied this change to both the document attachment and the standard media message.
