### PR TITLE
refactor(models): encapsulate model structures in getters

### DIFF
--- a/client.js
+++ b/client.js
@@ -9,7 +9,7 @@ import fsPromise from 'fs/promises'
 import colors from 'colors'
 import cron from 'node-cron'
 import extra from './lib/listeners-extra.js'
-import { models, structure } from './lib/models.js'
+import { models } from './lib/models.js'
 import system from './lib/adapter.js'
 import pm2 from './lib/pm2.js'
 
@@ -43,7 +43,7 @@ const connect = async () => {
 
       client.once('connect', async res => {
          try {
-            await system.proxy.init(models, structure, Config.database)
+            await system.proxy.init(models, models.structure, Config.database)
 
             const isEmpty = global.db.users.length === 0 && global.db.chats.length === 0
 
@@ -52,7 +52,7 @@ const connect = async () => {
 
                if (previous && Object.keys(previous).length > 0) {
                   console.dim('[Proxy DB] Old data found, starting migration...')
-                  await system.proxy.migrate(previous, structure)
+                  await system.proxy.migrate(previous, models.structure)
                   console.dim('[Proxy DB] Migration successful!')
                }
             }
@@ -88,7 +88,7 @@ const connect = async () => {
 
          cron.schedule('0 12 * * *', async () => {
             if (global?.db?.setting?.autobackup) {
-               const data = await system.proxy.backup(structure, Config.database)
+               const data = await system.proxy.backup(models.structure, Config.database)
                const now = new Intl.DateTimeFormat('en-CA', { timeZone: process.env.TZ, hour12: false, year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' }).format(new Date()).replace(', ', '_').replace(/:/g, '-')
                const filename = `${Config.database}-${now}.json`
                await fsPromise.writeFile(filename, data, 'utf-8')

--- a/lib/models.js
+++ b/lib/models.js
@@ -1,71 +1,80 @@
 export const models = {
-   users: {
-      lid: null,
-      afk: -1,
-      afkReason: '',
-      afkObj: {},
-      banned: false,
-      ban_temporary: 0,
-      ban_times: 0,
-      premium: false,
-      expired: 0,
-      lastseen: 0,
-      hit: 0,
-      warning: 0,
-      example: []
+   get users() {
+      return {
+         lid: null,
+         afk: -1,
+         afkReason: '',
+         afkObj: {},
+         banned: false,
+         ban_temporary: 0,
+         ban_times: 0,
+         premium: false,
+         expired: 0,
+         lastseen: 0,
+         hit: 0,
+         warning: 0,
+         example: []
+      }
    },
-   groups: {
-      activity: 0,
-      antidelete: true,
-      antilink: false,
-      antivirtex: false,
-      antitagsw: true,
-      filter: false,
-      left: false,
-      localonly: false,
-      mute: false,
-      viewonce: true,
-      autosticker: true,
-      member: {},
-      text_left: '',
-      text_welcome: '',
-      welcome: true,
-      expired: 0,
-      stay: false
+   get groups() {
+      return {
+         activity: 0,
+         antidelete: true,
+         antilink: false,
+         antivirtex: false,
+         antitagsw: true,
+         filter: false,
+         left: false,
+         localonly: false,
+         mute: false,
+         viewonce: true,
+         autosticker: true,
+         member: {},
+         text_left: '',
+         text_welcome: '',
+         welcome: true,
+         expired: 0,
+         stay: false
+      }
    },
-   chats: {
-      chat: 0,
-      lastchat: 0,
-      lastseen: 0
+   get chats() {
+      return {
+         chat: 0,
+         lastchat: 0,
+         lastseen: 0
+      }
    },
-   setting: {
-      autobackup: false,
-      autodownload: true,
-      antispam: true,
-      debug: false,
-      notifier: false,
-      error: [],
-      hidden: [],
-      pluginDisable: [],
-      receiver: [],
-      groupmode: false,
-      sk_pack: 'Sticker by',
-      sk_author: '© neoxr.js',
-      self: false,
-      noprefix: false,
-      multiprefix: true,
-      prefix: ['.', '#', '!', '/'],
-      toxic: ["ajg", "ajig", "anjas", "anjg", "anjim", "anjing", "anjrot", "anying", "asw", "autis", "babi", "bacod", "bacot", "bagong", "bajingan", "bangsad", "bangsat", "bastard", "bego", "bgsd", "biadab", "biadap", "bitch", "bngst", "bodoh", "bokep", "cocote", "coli", "colmek", "comli", "dajjal", "dancok", "dongo", "fuck", "gelay", "goblog", "goblok", "guoblog", "guoblok", "hairul", "henceut", "idiot", "itil", "jamet", "jancok", "jembut", "jingan", "kafir", "kanjut", "kanyut", "keparat", "kntl", "kontol", "lana", "loli", "lont", "lonte", "mancing", "meki", "memek", "ngentod", "ngentot", "ngewe", "ngocok", "ngtd", "njeng", "njing", "njinx", "oppai", "pantek", "pantek", "peler", "pepek", "pilat", "pler", "pornhub", "pucek", "puki", "pukimak", "redhub", "sange", "setan", "silit", "telaso", "tempek", "tete", "titit", "toket", "tolol", "tomlol", "tytyd", "wildan", "xnxx"],
-      online: true,
-      onlyprefix: '+',
-      owners: ['994408364923'],
-      lastReset: new Date * 1,
-      msg: 'Hi +tag 🪸\nI am an automated system (WhatsApp Bot) that can help to do something, search and get data / information only through WhatsApp.\n\n◦ *Module* : +module\n◦ *Database* : +db\n◦ *Library* : Baileys +version\n\nIf you find an error or want to upgrade premium plan contact the owner.',
-      style: 4,
-      cover: 'https://i.pinimg.com/736x/c7/2c/b0/c72cb05eb27c7d52e9cfa0cea059b1c8.jpg',
-      icon: null,
-      link: 'https://chat.whatsapp.com/D4OaImtQwH48CtlR0yt4Ff'
+   get setting() {
+      return {
+         autobackup: false,
+         autodownload: true,
+         antispam: true,
+         debug: false,
+         notifier: false,
+         error: [],
+         hidden: [],
+         pluginDisable: [],
+         receiver: [],
+         groupmode: false,
+         sk_pack: 'Sticker by',
+         sk_author: '© neoxr.js',
+         self: false,
+         noprefix: false,
+         multiprefix: true,
+         prefix: ['.', '#', '!', '/'],
+         toxic: ["ajg", "ajig", "anjas", "anjg", "anjim", "anjing", "anjrot", "anying", "asw", "autis", "babi", "bacod", "bacot", "bagong", "bajingan", "bangsad", "bangsat", "bastard", "bego", "bgsd", "biadab", "biadap", "bitch", "bngst", "bodoh", "bokep", "cocote", "coli", "colmek", "comli", "dajjal", "dancok", "dongo", "fuck", "gelay", "goblog", "goblok", "guoblog", "guoblok", "hairul", "henceut", "idiot", "itil", "jamet", "jancok", "jembut", "jingan", "kafir", "kanjut", "kanyut", "keparat", "kntl", "kontol", "lana", "loli", "lont", "lonte", "mancing", "meki", "memek", "ngentod", "ngentot", "ngewe", "ngocok", "ngtd", "njeng", "njing", "njinx", "oppai", "pantek", "pantek", "peler", "pepek", "pilat", "pler", "pornhub", "pucek", "puki", "pukimak", "redhub", "sange", "setan", "silit", "telaso", "tempek", "tete", "titit", "toket", "tolol", "tomlol", "tytyd", "wildan", "xnxx"],
+         online: true,
+         onlyprefix: '+',
+         owners: ['994408364923'],
+         lastReset: new Date * 1,
+         msg: 'Hi +tag 🪸\nI am an automated system (WhatsApp Bot) that can help to do something, search and get data / information only through WhatsApp.\n\n◦ *Module* : +module\n◦ *Database* : +db\n◦ *Library* : Baileys +version\n\nIf you find an error or want to upgrade premium plan contact the owner.',
+         style: 4,
+         cover: 'https://i.pinimg.com/736x/c7/2c/b0/c72cb05eb27c7d52e9cfa0cea059b1c8.jpg',
+         icon: null,
+         link: 'https://chat.whatsapp.com/D4OaImtQwH48CtlR0yt4Ff'
+      }
+   },
+   get structure() {
+      return { users: [], chats: [], groups: [], instance: [], statistic: {}, sticker: {}, setting: this.setting }
    }
 }
-
-export const structure = { users: [], chats: [], groups: [], instance: [], statistic: {}, sticker: {}, setting: {} }

--- a/plugins/owner/backup.js
+++ b/plugins/owner/backup.js
@@ -1,5 +1,5 @@
 import fsPromise from 'fs/promises'
-import { structure } from '../../lib/models.js'
+import { models } from '../../lib/models.js'
 
 export const run = {
    usage: ['backup'],
@@ -12,7 +12,7 @@ export const run = {
    }) => {
       try {
          await client.sendReact(m.chat, '🕒', m.key)
-         const data = await system.proxy.backup(structure, Config.database)
+         const data = await system.proxy.backup(models.structure, Config.database)
          const now = new Intl.DateTimeFormat('en-CA', { timeZone: process.env.TZ, hour12: false, year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' }).format(new Date()).replace(', ', '_').replace(/:/g, '-')
          const filename = `${Config.database}-${now}.json`
          await fsPromise.writeFile(filename, data, 'utf-8')

--- a/plugins/owner/restore.js
+++ b/plugins/owner/restore.js
@@ -1,5 +1,5 @@
 import fsPromise from 'fs/promises'
-import { structure } from '../../lib/models.js'
+import { models } from '../../lib/models.js'
 
 export const run = {
    usage: ['restore'],
@@ -16,7 +16,7 @@ export const run = {
             const fn = await Utils.getFile(await m.quoted.download())
             if (!fn.status) return m.reply(Utils.texted('bold', '🚩 File cannot be downloaded.'))
             const data = await fsPromise.readFile(fn.file, 'utf-8')
-            await system.proxy.restore(structure, data, Config.database)
+            await system.proxy.restore(models.structure, data, Config.database)
             m.reply('✅ Database was successfully restored.')
          } else m.reply(Utils.texted('bold', '🚩 Reply to the backup file first then reply with this feature.'))
       } catch (e) {


### PR DESCRIPTION
### Description
The model definitions have been refactored to use getters, providing a fresh object each time a model is accessed. This removes the direct `structure` export and improves encapsulation and data integrity. Corresponding updates were made in `client.js` to reference the new `models.structure` path.

### Changes Made
- Converted `users`, `groups`, and `chats` in `lib/models.js` from static objects to getter functions that return new objects.
- Removed the `structure` export from `lib/models.js`.
- Updated import in `client.js` to only import `models`.
- Replaced all usages of the removed `structure` with `models.structure` in `client.js` (initialization, migration, and backup calls).
