### PR TITLE
harden: sanitize child_process call in voicechanger.js

### DIFF
--- a/plugins/convert/voicechanger.js
+++ b/plugins/convert/voicechanger.js
@@ -1,7 +1,7 @@
 
 import { Converter } from '@neoxr/wb'
 import fs from 'node:fs'
-import { exec } from 'child_process'
+import { execFile } from 'child_process'
 
 export const run = {
    usage: ['bass', 'blown', 'chipmunk', 'deep', 'earrape', 'fast', 'fat', 'nightcore', 'reverse', 'robot', 'slow', 'smooth'],
@@ -33,7 +33,8 @@ export const run = {
             const buffer = await Converter.toAudio(await m.quoted.download(), 'mp3')
             const parse = await Utils.getFile(buffer)
             let ran = Utils.filename('mp3')
-            exec(`ffmpeg -i ${parse.file} ${set} ${ran}`, async (err, stderr, stdout) => {
+            const setArgs = set.trim().split(/\s+/).map(a => a.replace(/^"(.*)"$/, '$1'))
+            execFile('ffmpeg', ['-i', parse.file, ...setArgs, ran], async (err, stderr, stdout) => {
                fs.unlinkSync(parse.file)
                if (err) return client.reply(m.chat, Utils.texted('bold', `🚩 Conversion failed.`), m)
                let buff = fs.readFileSync(ran)


### PR DESCRIPTION
## Summary
Harden input handling in `plugins/convert/voicechanger.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `plugins/convert/voicechanger.js:36` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `m`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `plugins/convert/voicechanger.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=javascript.lang.security.detect-child-process.detect-child-process scanner=semgrep -->
