### PR TITLE
fix: Correct video mime type regex in sticker plugin

### DIFF
--- a/plugins/convert/sticker.js
+++ b/plugins/convert/sticker.js
@@ -93,7 +93,7 @@ export const run = {
                   if (/image\/(jpe?g|png)/.test(mime)) {
                      client.sendReact(m.chat, '🕒', m.key)
                      buffer = await q.download()
-                  } else if (/ video /.test(mime)) {
+                  } else if (/video/.test(mime)) {
                      client.sendReact(m.chat, '🕒', m.key)
                      if ((q.msg || q).seconds > 10) return client.reply(m.chat, Utils.texted('bold', `❌ Maximum video duration is 10 seconds.`), m)
                      buffer = await q.download()


### PR DESCRIPTION
### Description
Fixes the video mime type detection in the sticker conversion plugin by correcting the regular expression used to identify video files.

### Changes Made
- Updated the regex from `/ video /` to `/video/` to properly match video mime types.
- Ensured consistent handling of video files without altering other logic.
