### PR TITLE
feat: add message store support

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,13 @@ TZ = 'Asia/Jakarta'
 ### Database (Mongo, PostgreSQL, MySQL, Redis) — leave empty for local (JSON)
 DATABASE_URL = ''
 
+# Maximum message store
+MAX_STORE = 100
+
+# Store : Mongo / PostgreSQL / MySQL / Redis / Sqlite (Optional)
+# Leave it empty to use JSON by default.
+USE_STORE = ''
+
 # Maximum fetch buffer size (1 GiB)
 MAX_FETCH_BUFFER_BYTES = 1073741824
 

--- a/client.js
+++ b/client.js
@@ -13,6 +13,11 @@ import { models } from './lib/models.js'
 import system from './lib/adapter.js'
 import pm2 from './lib/pm2.js'
 
+import stores from '@neoxr/store'
+const store = stores.default || stores
+
+store.config({ max: Number(process.env.MAX_STORE || 100) })
+
 const connect = async () => {
    try {
       const client = new Client({
@@ -30,7 +35,7 @@ const connect = async () => {
             session: 'session',
             config: process.env.DATABASE_URL || ''
          },
-         engines: [baileys], // Init baileys as main engine
+         engines: [baileys, store], // Init baileys as main engine
          debug: false // Set to 'true' if you want to see how this module works :v
       }, {
          // This is the Baileys connection options section

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
    "homepage": "https://github.com/neoxr/neoxr-bot#readme",
    "dependencies": {
       "@adiwajshing/keyed-db": "^0.2.4",
+      "@neoxr/store": "github:neoxr/neoxr-bot#feat/store",
       "@neoxr/wb": "^6.0.0-rc.75",
       "audio-decode": "^2.1.3",
       "baileys": "npm:@itsliaaa/baileys",


### PR DESCRIPTION
### Description

Adds support for a configurable message store, allowing the bot to persist messages using various back‑ends (Mongo, PostgreSQL, MySQL, Redis, SQLite, or default JSON). The store size can be limited via an environment variable.

### Changes Made
- Added `MAX_STORE` and `USE_STORE` entries to `.env` for store configuration.
- Imported `@neoxr/store` in `client.js`, instantiated it, and configured the maximum store size from `process.env.MAX_STORE` (default 100).
- Updated the Baileys engine initialization to include the new `store` alongside `baileys`.
- Added `@neoxr/store` as a dependency in `package.json`, pointing to the `feat/store` branch.
