### PR TITLE
feat: enhance sticker conversion with media handling and store support

### DIFF
--- a/plugins/convert/sticker.js
+++ b/plugins/convert/sticker.js
@@ -1,3 +1,5 @@
+import { downloadContentFromMessage, downloadMediaMessage } from 'baileys'
+
 export const run = {
    usage: ['sticker'],
    hidden: ['s', 'sk', 'stiker', 'sgif'],
@@ -24,8 +26,9 @@ export const run = {
             client.sendSticker(m.chat, buffer, m, {
                packname: exif.sk_pack,
                author: exif.sk_author,
-               meta: true
-            })
+               meta: true,
+               store
+            }).then(() => m.react('✅'))
          } else {
             const q = m.quoted ? m.quoted : m
             const mime = (q.msg || q).mimetype || ''
@@ -37,7 +40,7 @@ export const run = {
 
                if (!result?.items?.length) return client.reply(m.chat, Utils.texted('bold', `❌ Album message doesn't exist in the store. Reupload or forward it to generate the sticker pack.`), m)
 
-               const results = await Promise.all(result.items.map(c => c.download()))
+               const results = await Promise.all(result.items.map(c => getMedia(c)))
 
                const stickers = results.map(buffer => ({ data: buffer }))
 
@@ -103,9 +106,11 @@ export const run = {
 
                   client.sendSticker(m.chat, buffer, m, {
                      packname: exif.sk_pack,
-                     author: exif.sk_author
+                     author: exif.sk_author,
+                     store
                   }).then(async () => {
                      buffer = null
+                     m.react('✅')
                   })
                }
             }
@@ -117,6 +122,46 @@ export const run = {
    },
    error: false,
    limit: true
+}
+
+async function getMedia(message) {
+   const msg = message?.msg || message
+
+   try {
+      const mime = msg?.mimetype || ''
+      const messageType = message?.mtype
+         ? message.mtype.replace(/Message|WithCaption/gi, '')
+         : mime?.split('/')?.[0]
+
+      const stream = await downloadContentFromMessage(
+         msg,
+         messageType
+      )
+
+      let buffer = Buffer.from([])
+
+      for await (const chunk of stream) {
+         buffer = Buffer.concat([buffer, chunk])
+      }
+
+      return buffer
+   } catch (streamError) {
+      const key = msg?.key || message?.key
+
+      if (!key) return null
+
+      try {
+         return await downloadMediaMessage(
+            {
+               key,
+               message: msg.message
+            },
+            'buffer'
+         )
+      } catch {
+         return null
+      }
+   }
 }
 
 async function retryUntil(fn, { retries = 5, delayMs = 800, factor = 1 } = {}) {


### PR DESCRIPTION
### Description
Adds robust media downloading for sticker conversion, integrates store metadata, and provides user feedback via reactions. Imports necessary utilities from `baileys` and introduces a helper to fetch media streams or fallback to media message download.

### Changes Made
* Imported `downloadContentFromMessage` and `downloadMediaMessage` from `baileys`.
* Updated `client.sendSticker` calls to include `store` and retain `meta: true`.
* Added `.then(() => m.react('✅'))` after successful sticker sends for user acknowledgment.
* Replaced direct `c.download()` calls with a new `getMedia(c)` helper to handle various media types.
* Implemented `async function getMedia(message)`:
  * Determines MIME type and message type.
  * Attempts to download content via stream using `downloadContentFromMessage`.
  * Falls back to `downloadMediaMessage` on stream errors.
  * Returns a Buffer or `null` on failure.
* Adjusted album handling to use `getMedia` for each item.
* Added reaction `m.react('✅')` after processing individual stickers.
